### PR TITLE
Handle getCurrentActivity returning null

### DIFF
--- a/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
+++ b/android/src/main/java/com/aakashns/reactnativedialogs/modules/DialogAndroid.java
@@ -199,11 +199,16 @@ public class DialogAndroid extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void show(ReadableMap options, final Callback callback) {
+        if (getCurrentActivity() == null) {
+            callback.invoke("error", "React Native Activity is null", options.toString());
+            return;
+        }
         mBuilder = new MaterialDialog.Builder(getCurrentActivity());
         try {
             applyOptions(mBuilder, options);
         } catch (Exception e) {
             callback.invoke("error", e.getMessage(), options.toString());
+            return;
         }
 
         if (options.hasKey("onPositive")) {


### PR DESCRIPTION
Found this crash in the wild, not sure exactly when it happens but we should handle the case where getCurrentActivity returns null. This will return an error to JS instead of causing a native crash.

```
FATAL EXCEPTION: mqt_native_modules
Process: com.th3rdwave, PID: 10591
java.lang.NullPointerException: Attempt to invoke virtual method 'int android.content.Context.getColor(int)' on a null object reference
	at d.h.e.a.a(ContextCompat.java:8)
	at f.b.a.s.a.b(DialogUtils.java:1)
	at f.b.a.f$d.<init>(MaterialDialog.java:36)
	at com.aakashns.reactnativedialogs.modules.DialogAndroid.show(DialogAndroid.java:1)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:18)
	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:2)
	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
	at android.os.Handler.handleCallback(Handler.java:790)
	at android.os.Handler.dispatchMessage(Handler.java:99)
```

I also fixed a missing return in the catch of applyOptions.